### PR TITLE
[JENKINS-27392] SimpleBuildWrapper.createLoggerDecorator

### DIFF
--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStepTest.java
@@ -28,12 +28,18 @@ import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Functions;
 import hudson.Launcher;
+import hudson.console.ConsoleLogFilter;
+import hudson.console.LineTransformationOutputStream;
+import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildWrapperDescriptor;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import jenkins.tasks.SimpleBuildWrapper;
 import org.jenkinsci.plugins.workflow.BuildWatcher;
@@ -45,9 +51,11 @@ import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import static org.junit.Assert.*;
 import org.junit.Assume;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -150,6 +158,47 @@ public class CoreWrapperStepTest {
         @TestExtension("envStickiness") public static class DescriptorImpl extends BuildWrapperDescriptor {
             @Override public String getDisplayName() {
                 return "OneVarWrapper";
+            }
+            @Override public boolean isApplicable(AbstractProject<?,?> item) {
+                return true;
+            }
+        }
+    }
+
+    @Ignore("TODO test prepared")
+    @Issue("JENKINS-27392")
+    @Test public void loggerDecorator() throws Exception {
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition("node {echo 'outside #1'; wrap([$class: 'WrapperWithLogger']) {echo 'inside the block'}; echo 'outside #2'}"));
+                WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
+                story.j.assertLogContains("outside #1", b);
+                story.j.assertLogContains("outside #2", b);
+                story.j.assertLogContains("INSIDE THE BLOCK", b);
+            }
+        });
+    }
+    public static class WrapperWithLogger extends SimpleBuildWrapper {
+        @DataBoundConstructor public WrapperWithLogger() {}
+        @Override public void setUp(SimpleBuildWrapper.Context context, Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment) throws IOException, InterruptedException {}
+        @Override public ConsoleLogFilter createLoggerDecorator(Run<?,?> build) {
+            return new UpcaseFilter();
+        }
+        private static class UpcaseFilter extends ConsoleLogFilter implements Serializable {
+            private static final long serialVersionUID = 1;
+            @SuppressWarnings("rawtypes") // inherited
+            @Override public OutputStream decorateLogger(AbstractBuild _ignore, final OutputStream logger) throws IOException, InterruptedException {
+                return new LineTransformationOutputStream() {
+                    @Override protected void eol(byte[] b, int len) throws IOException {
+                        logger.write(new String(b, 0, len).toUpperCase(Locale.ROOT).getBytes());
+                    }
+                };
+            }
+        }
+        @TestExtension("loggerDecorator") public static class DescriptorImpl extends BuildWrapperDescriptor {
+            @Override public String getDisplayName() {
+                return "WrapperWithLogger";
             }
             @Override public boolean isApplicable(AbstractProject<?,?> item) {
                 return true;

--- a/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStepTest.java
+++ b/aggregator/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStepTest.java
@@ -51,7 +51,6 @@ import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import static org.junit.Assert.*;
 import org.junit.Assume;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
@@ -165,7 +164,6 @@ public class CoreWrapperStepTest {
         }
     }
 
-    @Ignore("TODO test prepared")
     @Issue("JENKINS-27392")
     @Test public void loggerDecorator() throws Exception {
         story.addStep(new Statement() {

--- a/basic-steps/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStep.java
+++ b/basic-steps/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStep.java
@@ -29,6 +29,7 @@ import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.console.ConsoleLogFilter;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildWrapperDescriptor;
@@ -75,6 +76,10 @@ public class CoreWrapperStep extends AbstractStepImpl {
             Map<String,String> overrides = c.getEnv();
             if (!overrides.isEmpty()) {
                 bodyInvoker.withContext(EnvironmentExpander.merge(getContext().get(EnvironmentExpander.class), new ExpanderImpl(overrides)));
+            }
+            ConsoleLogFilter filter = step.delegate.createLoggerDecorator(run);
+            if (filter != null) {
+                bodyInvoker.withContext(BodyInvoker.mergeConsoleLogFilters(getContext().get(ConsoleLogFilter.class), filter));
             }
             SimpleBuildWrapper.Disposer disposer = c.getDisposer();
             bodyInvoker.withCallback(disposer != null ? new Callback(disposer) : BodyExecutionCallback.wrap(getContext())).start();

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.607</version> <!-- TODO SimpleBuildWrapper-JENKINS-27392 branch -->
+        <version>1.609</version>
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-pom</artifactId>
@@ -99,26 +99,6 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
-        <dependency> <!-- TODO SimpleBuildWrapper-JENKINS-27392 branch @ a52d665180a7b11dcd64673c3f08b719f6c9f908 -->
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-core</artifactId>
-            <version>1.608-20150331.141653-1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-war</artifactId>
-            <version>1.608-20150331.141722-1</version>
-            <type>war</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-war</artifactId>
-            <version>1.608-20150331.141722-1</version>
-            <classifier>war-for-test</classifier>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.608-SNAPSHOT</version> <!-- TODO SimpleBuildWrapper-JENKINS-27392 -->
+        <version>1.607</version> <!-- TODO SimpleBuildWrapper-JENKINS-27392 branch -->
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-pom</artifactId>
@@ -99,6 +99,26 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <dependency> <!-- TODO SimpleBuildWrapper-JENKINS-27392 branch @ a52d665180a7b11dcd64673c3f08b719f6c9f908 -->
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-core</artifactId>
+            <version>1.608-20150331.141653-1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-war</artifactId>
+            <version>1.608-20150331.141722-1</version>
+            <type>war</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-war</artifactId>
+            <version>1.608-20150331.141722-1</version>
+            <classifier>war-for-test</classifier>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.599</version>
+        <version>1.608-SNAPSHOT</version> <!-- TODO SimpleBuildWrapper-JENKINS-27392 -->
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-pom</artifactId>


### PR DESCRIPTION
[JENKINS-27392](https://issues.jenkins-ci.org/browse/JENKINS-27392)

Extending `SimpleBuildWrapper` support to include console decoration.

Downstream of https://github.com/jenkinsci/workflow-plugin/pull/37 and https://github.com/jenkinsci/jenkins/pull/1634.

Due to the way GitHub forks work, it does not seem that I can make this a PR in the origin repo, so there is no PR build for it. Sigh.

@reviewbybees

Snapshot information @ 874c4618f43316e096562499f0f6a3636951919a:

```
workflow-pom/1.5-SNAPSHOT/workflow-pom-1.5-20150331.145506-7.pom
workflow-step-api/1.5-SNAPSHOT/workflow-step-api-1.5-20150331.145606-6.hpi
workflow-step-api/1.5-SNAPSHOT/workflow-step-api-1.5-20150331.145606-6.pom
workflow-step-api/1.5-SNAPSHOT/workflow-step-api-1.5-20150331.145606-6.jar
workflow-step-api/1.5-SNAPSHOT/workflow-step-api-1.5-20150331.145606-6-tests.jar
workflow-api/1.5-SNAPSHOT/workflow-api-1.5-20150331.145655-6.hpi
workflow-api/1.5-SNAPSHOT/workflow-api-1.5-20150331.145655-6.pom
workflow-api/1.5-SNAPSHOT/workflow-api-1.5-20150331.145655-6.jar
workflow-support/1.5-SNAPSHOT/workflow-support-1.5-20150331.150001-6.hpi
workflow-support/1.5-SNAPSHOT/workflow-support-1.5-20150331.150001-6.pom
workflow-support/1.5-SNAPSHOT/workflow-support-1.5-20150331.150001-6.jar
workflow-support/1.5-SNAPSHOT/workflow-support-1.5-20150331.150001-6-tests.jar
workflow-basic-steps/1.5-SNAPSHOT/workflow-basic-steps-1.5-20150331.150304-6.hpi
workflow-basic-steps/1.5-SNAPSHOT/workflow-basic-steps-1.5-20150331.150304-6.pom
workflow-basic-steps/1.5-SNAPSHOT/workflow-basic-steps-1.5-20150331.150304-6.jar
workflow-durable-task-step/1.5-SNAPSHOT/workflow-durable-task-step-1.5-20150331.150349-6.hpi
workflow-durable-task-step/1.5-SNAPSHOT/workflow-durable-task-step-1.5-20150331.150349-6.pom
workflow-durable-task-step/1.5-SNAPSHOT/workflow-durable-task-step-1.5-20150331.150349-6.jar
workflow-scm-step/1.5-SNAPSHOT/workflow-scm-step-1.5-20150331.150539-6.hpi
workflow-scm-step/1.5-SNAPSHOT/workflow-scm-step-1.5-20150331.150539-6.pom
workflow-scm-step/1.5-SNAPSHOT/workflow-scm-step-1.5-20150331.150539-6.jar
workflow-cps/1.5-SNAPSHOT/workflow-cps-1.5-20150331.150709-6.hpi
workflow-cps/1.5-SNAPSHOT/workflow-cps-1.5-20150331.150709-6.pom
workflow-cps/1.5-SNAPSHOT/workflow-cps-1.5-20150331.150709-6.jar
workflow-cps/1.5-SNAPSHOT/workflow-cps-1.5-20150331.150709-6-tests.jar
workflow-cps-global-lib/1.5-SNAPSHOT/workflow-cps-global-lib-1.5-20150331.150811-6.hpi
workflow-cps-global-lib/1.5-SNAPSHOT/workflow-cps-global-lib-1.5-20150331.150811-6.pom
workflow-cps-global-lib/1.5-SNAPSHOT/workflow-cps-global-lib-1.5-20150331.150811-6.jar
workflow-job/1.5-SNAPSHOT/workflow-job-1.5-20150331.150925-6.hpi
workflow-job/1.5-SNAPSHOT/workflow-job-1.5-20150331.150925-6.pom
workflow-job/1.5-SNAPSHOT/workflow-job-1.5-20150331.150925-6.jar
```
